### PR TITLE
Cope with exit code 5 when no tests are found

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
+        python-version: '3.14'
         cache: pip
         cache-dependency-path: ${{ steps.copy-requirements.outputs.directory }}/**requirements.txt
 

--- a/action.yml
+++ b/action.yml
@@ -27,11 +27,27 @@ runs:
     - name: Run Scoring tests
       shell: bash
       run: |
+        # Do our own error handling as unittest discover exits with code 5 to
+        # mean "no tests found", which is fine.
+        set +e
         python3 -m unittest discover --buffer scoring/
+        result=$?
+        set -x
+        if [ "$result" -ne 0 ] && [ "$result" -ne 5 ]
+        then
+          exit $result
+        fi
 
         if [ -d scoring/tests/ ]
         then
+          set +e
           python3 -m unittest discover --buffer scoring/tests/
+          set -x
+          result=$?
+          if [ "$result" -ne 0 ] && [ "$result" -ne 5 ]
+          then
+            exit $result
+          fi
         fi
 
     - name: Run Compstate Validation


### PR DESCRIPTION
Maybe at some point this should be an option, however for now maintain the previous behaviour.