### PR TITLE
Bump to Python 3.11

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.10'
+        python-version: '3.11'
         cache: pip
         cache-dependency-path: ${{ steps.copy-requirements.outputs.directory }}/**requirements.txt
 


### PR DESCRIPTION
This creates breathing room above SRComp's minimum supported version.